### PR TITLE
LZA-42: add initial terraform setup for repositories

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -5,3 +5,10 @@
 We use GitHub Actions and Workflows to automate processes within the repository.
 
 These actions can be found within the [workflows](./workflows) directory.
+
+## Dependabot
+
+[Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot) is used within the project to automatically update relevant dependencies within the
+repository. It is configured to check daily and submit pull requests with version bumps.
+
+The configuration can be found within the [dependabot.yaml](./dependabot.yaml) file.

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,7 @@
+# GitHub Configuration
+
+## Workflows
+
+We use GitHub Actions and Workflows to automate processes within the repository.
+
+These actions can be found within the [workflows](./workflows) directory.

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "(GHA)"
+    reviewers:
+      - "UKHomeOffice/core-cloud-devops"
+    labels:
+      - "dependencies"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,3 +10,13 @@ updates:
       - "UKHomeOffice/core-cloud-devops"
     labels:
       - "dependencies"
+  - package-ecosystem: "terraform"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "(TF)"
+    reviewers:
+      - "UKHomeOffice/core-cloud-devops"
+    labels:
+      - "dependencies"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Configure AWS IdP Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::850744974572:role/AWSA-GitHubTerraformAssume-Role
+          role-to-assume: arn:aws:iam::850744974572:role/AWSA-GitHubTerraformAllState-Role
           role-session-name: GitHubActions
           retry-max-attempts: 5
           aws-region: eu-west-2
@@ -36,8 +36,7 @@ jobs:
         run: |
           terraform init -reconfigure \
           -backend-config="bucket=${{ secrets.TF_BUCKET }}" \
-          -backend-config="region=eu-west-2" \
-          -backend-config="assume_role={role_arn=\"arn:aws:iam::850744974572:role/AWSA-GitHubTerraformAllState-Role\"}"
+          -backend-config="region=eu-west-2"
 
       - name: Terraform Validate
         run: terraform validate

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,49 @@
+name: Apply Terraform Configuration
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+
+jobs:
+  validate-plan-apply:
+    name: Terraform Validate, Plan, and Apply
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_OWNER: ukhomeoffice
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ~1.6.0
+
+      - name: Configure AWS IdP Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::850744974572:role/AWSA-GitHubTerraformAssume-Role
+          role-session-name: GitHubActions
+          retry-max-attempts: 5
+          aws-region: eu-west-2
+
+      - name: Terraform Init
+        run: |
+          terraform init -reconfigure \
+          -backend-config="bucket=${{ secrets.TF_BUCKET }}" \
+          -backend-config="region=eu-west-2" \
+          -backend-config="assume_role={role_arn=\"arn:aws:iam::850744974572:role/AWSA-GitHubTerraformAllState-Role\"}"
+
+      - name: Terraform Validate
+        run: terraform validate
+
+      - name: Terraform Plan
+        run: terraform plan -out=tfplan
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve tfplan

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Configure AWS IdP Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::850744974572:role/AWSA-GitHubTerraformAssume-Role
+          role-to-assume: arn:aws:iam::850744974572:role/AWSA-GitHubTerraformReadState-Role
           role-session-name: GitHubActions
           retry-max-attempts: 5
           aws-region: eu-west-2
@@ -36,8 +36,7 @@ jobs:
         run: |
           terraform init -reconfigure \
           -backend-config="bucket=${{ secrets.TF_BUCKET }}" \
-          -backend-config="region=eu-west-2" \
-          -backend-config="assume_role={role_arn=\"arn:aws:iam::850744974572:role/AWSA-GitHubTerraformReadState-Role\"}"
+          -backend-config="region=eu-west-2"
 
       - name: Terraform Validate
         run: terraform validate

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -30,7 +30,7 @@ jobs:
         id: aws-credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::850744974572:role/AWSA-GitHubTerraformConfigState-Role
+          role-to-assume: arn:aws:iam::850744974572:role/AWSA-GitHubTerraformReadState-Role
           role-session-name: GitHubActions
           aws-region: eu-west-2
           retry-max-attempts: 5

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,32 @@
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  validate:
+    name: Validate Terraform
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_OWNER: ukhomeoffice
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ~1.6.0
+
+      - name: Terraform Init
+        run: terraform init -reconfigure -backend-config="bucket=${{ secrets.TF_BUCKET }}" -backend-config="region=${{ secrets.TF_BUCKET_REGION }}" -backend-config="access_key=<<TODO>>"  -backend-config="secret_key=<<TODO>>"
+
+      - name: Terraform Validate
+        run: terraform validate
+
+      - name: Terraform Format
+        run: terraform fmt -check
+
+      - name: Terraform Plan
+        run: terraform plan

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -26,8 +26,23 @@ jobs:
         with:
           terraform_version: ~1.6.0
 
+      - name: Configure AWS Credentials
+        id: aws-credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ vars.ACCOUNT_ID }}:role/AWSA-GitHubTerraformConfigState-Role
+          role-session-name: GitHubActions
+          aws-region: eu-west-2
+          retry-max-attempts: 5
+          output-credentials: true
+
       - name: Terraform Init
-        run: terraform init -reconfigure -backend-config="bucket=${{ secrets.TF_BUCKET }}" -backend-config="region=${{ secrets.TF_BUCKET_REGION }}" -backend-config="assume_role.role_arn=${{ secrets.TF_GITHUB_ROLE_ARN }}"
+        run: |
+          terraform init -reconfigure \
+          -backend-config="bucket=${{ secrets.TF_BUCKET }}" \
+          -backend-config="region=${{ secrets.TF_BUCKET_REGION }}" \
+          -backend-config="access_key=${{ steps.aws-credentials.outputs.aws-access-key-id }}"
+          -backend-config="secret_key=${{ steps.aws-credentials.outputs.aws-secret-access-key }}"
 
       - name: Terraform Validate
         run: terraform validate

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -30,7 +30,7 @@ jobs:
         id: aws-credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ vars.ACCOUNT_ID }}:role/AWSA-GitHubTerraformConfigState-Role
+          role-to-assume: arn:aws:iam::850744974572:role/AWSA-GitHubTerraformConfigState-Role
           role-session-name: GitHubActions
           aws-region: eu-west-2
           retry-max-attempts: 5
@@ -40,7 +40,7 @@ jobs:
         run: |
           terraform init -reconfigure \
           -backend-config="bucket=${{ secrets.TF_BUCKET }}" \
-          -backend-config="region=${{ secrets.TF_BUCKET_REGION }}" \
+          -backend-config="region=eu-west-2" \
           -backend-config="access_key=${{ steps.aws-credentials.outputs.aws-access-key-id }}" \
           -backend-config="secret_key=${{ steps.aws-credentials.outputs.aws-secret-access-key }}"
 

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -33,17 +33,10 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::850744974572:role/AWSA-GitHubTerraformAssumption-Role
-          role-session-name: GitHubActions
-          aws-region: eu-west-2
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: eu-west-2
           role-to-assume: arn:aws:iam::850744974572:role/AWSA-GitHubTerraformReadState-Role
-          role-session-name: TerraformRead
-          role-chaining: true
+          role-session-name: GitHubActions
+          retry-max-attempts: 5
+          aws-region: eu-west-2
 
       - name: Terraform Init
         run: |

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -41,7 +41,7 @@ jobs:
           terraform init -reconfigure \
           -backend-config="bucket=${{ secrets.TF_BUCKET }}" \
           -backend-config="region=${{ secrets.TF_BUCKET_REGION }}" \
-          -backend-config="access_key=${{ steps.aws-credentials.outputs.aws-access-key-id }}"
+          -backend-config="access_key=${{ steps.aws-credentials.outputs.aws-access-key-id }}" \
           -backend-config="secret_key=${{ steps.aws-credentials.outputs.aws-secret-access-key }}"
 
       - name: Terraform Validate

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -30,10 +30,18 @@ jobs:
         with:
           terraform_version: ~1.6.0
 
-      - name: Configure AWS Credentials
+      - name: Configure AWS IdP Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::850744974572:role/AWSA-GitHubTerraformAssume-Role
+          role-session-name: GitHubActions
+          retry-max-attempts: 5
+          aws-region: eu-west-2
+
+      - name: Configure AWS S3 Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::850744974572:role/AWSA-GitHubTerraformReadState-Role
           role-session-name: GitHubActions
           retry-max-attempts: 5
           aws-region: eu-west-2
@@ -43,7 +51,7 @@ jobs:
           terraform init -reconfigure \
           -backend-config="bucket=${{ secrets.TF_BUCKET }}" \
           -backend-config="region=eu-west-2" \
-          -backend-config="assume_role.role_arn=arn:aws:iam::850744974572:role/AWSA-GitHubTerraformReadState-Role"
+          -backend-config="assume_role={role_arn=\"arn:aws:iam::850744974572:role/AWSA-GitHubTerraformReadState-Role\"}"
 
       - name: Terraform Validate
         run: terraform validate

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           terraform init -reconfigure \
           -backend-config="bucket=${{ secrets.TF_BUCKET }}" \
-          -backend-config="region=eu-west-2" 
+          -backend-config="region=eu-west-2" \
           -backend-config="assume_role.role_arn=arn:aws:iam::850744974572:role/AWSA-GitHubTerraformReadState-Role"
 
       - name: Terraform Validate

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -3,11 +3,6 @@ on:
   pull_request:
     branches:
       - main
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
 
 permissions:
   id-token: write   # This is required for requesting the JWT
@@ -15,7 +10,6 @@ permissions:
 
 jobs:
   validate:
-    if: github.event.pull_request.draft == false
     name: Validate Terraform
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::850744974572:role/AWSA-GitHubTerraformReadState-Role
+          role-to-assume: arn:aws:iam::850744974572:role/AWSA-GitHubTerraformAssume-Role
           role-session-name: GitHubActions
           retry-max-attempts: 5
           aws-region: eu-west-2
@@ -43,6 +43,7 @@ jobs:
           terraform init -reconfigure \
           -backend-config="bucket=${{ secrets.TF_BUCKET }}" \
           -backend-config="region=eu-west-2" 
+          -backend-config="assume_role.role_arn=arn:aws:iam::850744974572:role/AWSA-GitHubTerraformReadState-Role"
 
       - name: Terraform Validate
         run: terraform validate

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -38,14 +38,6 @@ jobs:
           retry-max-attempts: 5
           aws-region: eu-west-2
 
-      - name: Configure AWS S3 Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::850744974572:role/AWSA-GitHubTerraformReadState-Role
-          role-session-name: GitHubActions
-          retry-max-attempts: 5
-          aws-region: eu-west-2
-
       - name: Terraform Init
         run: |
           terraform init -reconfigure \

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -9,6 +9,10 @@ on:
       - reopened
       - ready_for_review
 
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+
 jobs:
   validate:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -27,7 +27,7 @@ jobs:
           terraform_version: ~1.6.0
 
       - name: Terraform Init
-        run: terraform init -reconfigure -backend-config="bucket=${{ secrets.TF_BUCKET }}" -backend-config="region=${{ secrets.TF_BUCKET_REGION }}" -backend-config="access_key=<<TODO>>"  -backend-config="secret_key=<<TODO>>"
+        run: terraform init -reconfigure -backend-config="bucket=${{ secrets.TF_BUCKET }}" -backend-config="region=${{ secrets.TF_BUCKET_REGION }}" -backend-config="assume_role.role_arn=${{ secrets.TF_GITHUB_ROLE_ARN }}"
 
       - name: Terraform Validate
         run: terraform validate

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,10 +1,17 @@
+name: Validate Terraform
 on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 jobs:
   validate:
+    if: github.event.pull_request.draft == false
     name: Validate Terraform
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -31,7 +31,6 @@ jobs:
           terraform_version: ~1.6.0
 
       - name: Configure AWS Credentials
-        id: aws-credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::850744974572:role/AWSA-GitHubTerraformAssumption-Role
@@ -39,7 +38,6 @@ jobs:
           aws-region: eu-west-2
 
       - name: Configure AWS Credentials
-        id: aws-credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-west-2

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -34,19 +34,24 @@ jobs:
         id: aws-credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::850744974572:role/AWSA-GitHubTerraformReadState-Role
+          role-to-assume: arn:aws:iam::850744974572:role/AWSA-GitHubTerraformAssumption-Role
           role-session-name: GitHubActions
           aws-region: eu-west-2
-          retry-max-attempts: 5
-          output-credentials: true
+
+      - name: Configure AWS Credentials
+        id: aws-credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: eu-west-2
+          role-to-assume: arn:aws:iam::850744974572:role/AWSA-GitHubTerraformReadState-Role
+          role-session-name: TerraformRead
+          role-chaining: true
 
       - name: Terraform Init
         run: |
           terraform init -reconfigure \
           -backend-config="bucket=${{ secrets.TF_BUCKET }}" \
-          -backend-config="region=eu-west-2" \
-          -backend-config="access_key=${{ steps.aws-credentials.outputs.aws-access-key-id }}" \
-          -backend-config="secret_key=${{ steps.aws-credentials.outputs.aws-secret-access-key }}"
+          -backend-config="region=eu-west-2" 
 
       - name: Terraform Validate
         run: terraform validate

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_OWNER: ukhomeoffice
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "5.42.0"
+  constraints = "5.42.0"
+  hashes = [
+    "h1:CZUAXhUhMIuIyTPm9VDcvOZgM1Lsl9tuKm5wW9tBEsM=",
+    "zh:0f97039c6b70295c4a82347bc8a0bcea700b3fb3df0e0be53585da025584bb7c",
+    "zh:12e78898580cc2a72b5f2a77e191b158f88e974b0500489b691f34842288745c",
+    "zh:23660933e4f00293c0d4d6cd6b4d72e382c0df46b70cecf22b5c4c090d3b61e3",
+    "zh:74119174b46d8d197dd209a246bf8b5db113c66467e02c831e68a8ceea312d3e",
+    "zh:829c4c0c202fc646eb0e1759eb9c8f0757df5295be2d3344b8fd6ca8ce9ef33b",
+    "zh:92043e667f520aee4e08a10a183ad5abe5487f3e9c8ad5a55ea1358b14b17b1a",
+    "zh:998909806b4ff42cf480fcd359ec1f12b868846f89284b991987f55de24876b7",
+    "zh:9f758447db3bf386516562abd6da1e54d22ddc207bda25961d2b5b049f32da0f",
+    "zh:a6259215612d4d6a281c671b2d5aa3a0a0b0a3ae92ed60b633998bb692e922d3",
+    "zh:ad7d78056beb44191911db9443bf5eec41a3d60e7b01def2a9e608d1c4288d27",
+    "zh:b697e7b0abef3000e1db482c897b82cd455621b488bb6c4cd3d270763d7b08ac",
+    "zh:db8e849eded8aebff780f89ab7e1339053d2f15c1c8f94103d70266a090527ad",
+    "zh:e5bdbb85fb148dd75877a7b94b595d4e8680e495c241db02c4b12b91e9d08953",
+    "zh:ee812c5fd77d3817fb688f720e5eb42d7ff04db67a125de48b05458c9f657483",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
-# core-cloud-github-config
-GitHub repository configuration for Core Cloud repositories
+# Core Cloud Repository Configuration
+
+This repository contains the configuration for the Core Cloud GitHub repositories and utilises Terraform to ensure 
+consistency in configuration. This facilitates the monitoring of any drift from the desired state.
+
+The following settings are configured:
+- Repositories
+- Repository Team Membership
+
+## Configuration
+
+Repositories have to be manually added to locals block within the [repositories](./repositories.tf) file. This ensures only repositories 
+that are explicitly owned by the Core Cloud team are managed.
+
+### Configurable Settings
+
+Each repository has a number of configurable settings. These can be altered by adding the setting into the required repositories object.
+
+The following settings are currently configurable:
+
+| Setting    | Description                      | Default |
+|------------|----------------------------------|---------|
+| visibility | The visibility of the repository | private |
+
+It is designed so that additional settings can be added as required, with sensible defaults provided.

--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ repositories object.
 
 The following settings are currently configurable:
 
-| Setting                                           | Description                                             | Required | Default |
-|---------------------------------------------------|---------------------------------------------------------|----------|---------|
-| visibility                                        | The visibility of the repository                        | Yes      |         |
-| branch_protection.required_approving_review_count | The number of approving reviews required before merging |          | 1       |
+| Setting                                           | Description                                             | Required | Default                   |
+|---------------------------------------------------|---------------------------------------------------------|----------|---------------------------|
+| visibility                                        | The visibility of the repository                        | Yes      |                           |
+| description                                       | The description of the repository                       | No       | SAS Core Cloud Repository |
+| homepage_url                                      | The homepage URL of the repository                      | No       |                           |
+| branch_protection.required_approving_review_count | The number of approving reviews required before merging | No       | 2                         |
 
 > Visibility can be one of `public`, `private`, or `internal`. It does not have a default value and must be set on each 
 > repository.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Each repository has a number of configurable settings. These can be altered by a
 
 The following settings are currently configurable:
 
-| Setting    | Description                      | Default |
-|------------|----------------------------------|---------|
-| visibility | The visibility of the repository | private |
+| Setting                                           | Description                                             | Default |
+|---------------------------------------------------|---------------------------------------------------------|---------|
+| visibility                                        | The visibility of the repository                        | private |
+| branch_protection.required_approving_review_count | The number of approving reviews required before merging | 1       |
 
 It is designed so that additional settings can be added as required, with sensible defaults provided.

--- a/README.md
+++ b/README.md
@@ -16,17 +16,8 @@ only repositories that are explicitly owned by the Core Cloud team are managed.
 
 ### Configurable Settings
 
-Each repository has a number of configurable settings. These can be altered by adding the setting into the required 
+Each repository has a number of configurable settings. These can be altered by adding the setting into the locals 
 repositories object.
-
-The following settings are currently configurable:
-
-| Setting                                           | Description                                             | Required | Default                   |
-|---------------------------------------------------|---------------------------------------------------------|----------|---------------------------|
-| visibility                                        | The visibility of the repository                        | Yes      |                           |
-| description                                       | The description of the repository                       | No       | SAS Core Cloud Repository |
-| homepage_url                                      | The homepage URL of the repository                      | No       |                           |
-| branch_protection.required_approving_review_count | The number of approving reviews required before merging | No       | 2                         |
 
 > Visibility can be one of `public`, `private`, or `internal`. It does not have a default value and must be set on each 
 > repository.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,30 @@
 # Core Cloud Repository Configuration
 
 This repository contains the configuration for the Core Cloud GitHub repositories and utilises Terraform to ensure 
-consistency in configuration. This facilitates the monitoring of any drift from the desired state.
+consistency in configuration. This facilitates the application of desired state and monitoring drift.
 
 The following settings are configured:
 - Repositories
 - Repository Team Membership
+- Repository Branch Protection
+- Repository Action Permissions
 
 ## Configuration
 
-Repositories have to be manually added to locals block within the [repositories](./repositories.tf) file. This ensures only repositories 
-that are explicitly owned by the Core Cloud team are managed.
+Repositories have to be manually added to locals block within the [repositories](./repositories.tf) file. This ensures 
+only repositories that are explicitly owned by the Core Cloud team are managed.
 
 ### Configurable Settings
 
-Each repository has a number of configurable settings. These can be altered by adding the setting into the required repositories object.
+Each repository has a number of configurable settings. These can be altered by adding the setting into the required 
+repositories object.
 
 The following settings are currently configurable:
 
-| Setting                                           | Description                                             | Default |
-|---------------------------------------------------|---------------------------------------------------------|---------|
-| visibility                                        | The visibility of the repository                        | private |
-| branch_protection.required_approving_review_count | The number of approving reviews required before merging | 1       |
+| Setting                                           | Description                                             | Required | Default |
+|---------------------------------------------------|---------------------------------------------------------|----------|---------|
+| visibility                                        | The visibility of the repository                        | Yes      |         |
+| branch_protection.required_approving_review_count | The number of approving reviews required before merging |          | 1       |
 
-It is designed so that additional settings can be added as required, with sensible defaults provided.
+> Visibility can be one of `public`, `private`, or `internal`. It does not have a default value and must be set on each 
+> repository.

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.42.0"
+    }
+  }
+}
+
+provider "github" {
+  owner = "UKHomeOffice" # TODO: this may want to be sourced from the `GITHUB_OWNER` action environment variable
+  token = "" # TODO: this should be passed through as a environment variable in the action `GITHUB_TOKEN`
+}

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,9 @@ terraform {
       version = "~> 5.42.0"
     }
   }
+  backend "s3" {
+    key = "github/terraform.tfstate"
+  }
 }
 
 provider "github" {

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,4 @@ terraform {
   }
 }
 
-provider "github" {
-  owner = "UKHomeOffice" # TODO: this may want to be sourced from the `GITHUB_OWNER` action environment variable
-  token = "" # TODO: this should be passed through as a environment variable in the action `GITHUB_TOKEN`
-}
+provider "github" { }

--- a/main.tf
+++ b/main.tf
@@ -10,4 +10,4 @@ terraform {
   }
 }
 
-provider "github" { }
+provider "github" {}

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,8 @@ terraform {
   backend "s3" {
     key = "github/terraform.tfstate"
   }
+
+  required_version = "~>1.6.0"
 }
 
 provider "github" {}

--- a/repositories.tf
+++ b/repositories.tf
@@ -1,20 +1,20 @@
 locals {
   default_repo = {
     branch_protection = {
-      required_approving_review_count = 1 # TODO: default to one reviewer except for repositories that need additional scrutiny
+      required_approving_review_count = 2
     }
   }
 
   repository_config = {
     "core-cloud" = {
       visibility = "public"
+
+      branch_protection = {
+        required_approving_review_count = 1
+      }
     },
     "core-cloud-lza-config" = {
       visibility = "internal"
-
-      branch_protection = {
-        required_approving_review_count = 2
-      }
     },
     "core-cloud-github-config" = {
       visibility = "public"

--- a/repositories.tf
+++ b/repositories.tf
@@ -1,5 +1,7 @@
 locals {
   default_repo = {
+    description = "SAS Core Cloud Repository"
+
     branch_protection = {
       required_approving_review_count = 2
     }
@@ -8,6 +10,7 @@ locals {
   repository_config = {
     "core-cloud" = {
       visibility = "public"
+      description = "SAS Core Cloud Documentation"
 
       branch_protection = {
         required_approving_review_count = 1
@@ -15,9 +18,11 @@ locals {
     },
     "core-cloud-lza-config" = {
       visibility = "internal"
+      description = "SAS Core Cloud LZA Config"
     },
     "core-cloud-github-config" = {
       visibility = "public"
+      description = "GitHub repository configuration for Core Cloud repositories"
     }
   }
 
@@ -30,6 +35,7 @@ locals {
 resource "github_repository" "core_cloud_repositories" {
   for_each           = local.repositories
   name               = each.key
+  description        = each.value.description
   visibility         = each.value.visibility
   has_issues         = false
   has_projects       = false

--- a/repositories.tf
+++ b/repositories.tf
@@ -31,3 +31,17 @@ resource "github_repository" "core_cloud_repositories" {
   allow_squash_merge = true
   allow_rebase_merge = true # TODO: Do we actually want to allow this?
 }
+
+resource "github_team_repository" "core_cloud_admin_team_repositories" {
+  for_each = local.repositories
+  repository = each.key
+  team_id = data.github_team.core_cloud_admin.id
+  permission = "admin"
+}
+
+resource "github_team_repository" "core_cloud_devops_team_repositories" {
+  for_each = local.repositories
+  repository = each.key
+  team_id = data.github_team.core_cloud_devops.id
+  permission = "push"
+}

--- a/repositories.tf
+++ b/repositories.tf
@@ -1,7 +1,5 @@
 locals {
   default_repo = {
-    description = "SAS Core Cloud Repository"
-
     branch_protection = {
       required_approving_review_count = 2
     }

--- a/repositories.tf
+++ b/repositories.tf
@@ -1,19 +1,9 @@
 locals {
-  default_repo = {
-    branch_protection = {
-      required_approving_review_count = 2
-    }
-  }
-
-  repository_config = {
+  repositories = {
     "core-cloud" = {
       visibility   = "public"
       description  = "SAS Core Cloud Documentation"
       homepage_url = "https://ukhomeoffice.github.io/core-cloud/"
-
-      branch_protection = {
-        required_approving_review_count = 1
-      }
     },
     "core-cloud-lza-config" = {
       visibility  = "internal"
@@ -23,11 +13,6 @@ locals {
       visibility  = "public"
       description = "GitHub repository configuration for Core Cloud repositories"
     }
-  }
-
-  # Sets the default of specific values if the object key is not set.
-  repositories = {
-    for k, v in local.repository_config : k => merge(local.default_repo, v)
   }
 }
 
@@ -84,7 +69,7 @@ resource "github_branch_protection" "main" {
 
   required_pull_request_reviews {
     require_last_push_approval      = true
-    required_approving_review_count = local.repositories[each.key].branch_protection.required_approving_review_count
+    required_approving_review_count = 1
   }
 }
 

--- a/repositories.tf
+++ b/repositories.tf
@@ -70,7 +70,7 @@ resource "github_team_repository" "core_cloud_admin_team_repositories" {
 }
 
 resource "github_team_repository" "core_cloud_devops_team_repositories" {
-  for_each   = local.repositories
+  for_each   = github_repository.core_cloud_repositories
   repository = each.key
   team_id    = data.github_team.core_cloud_devops.id
   permission = "push"
@@ -81,8 +81,8 @@ resource "github_team_repository" "core_cloud_devops_team_repositories" {
 }
 
 resource "github_branch_protection" "main" {
-  for_each      = local.repositories
-  repository_id = github_repository.core_cloud_repositories[each.key].node_id
+  for_each      = github_repository.core_cloud_repositories
+  repository_id = each.key
 
   pattern                         = "main"
   enforce_admins                  = true
@@ -93,7 +93,7 @@ resource "github_branch_protection" "main" {
 
   required_pull_request_reviews {
     require_last_push_approval      = true
-    required_approving_review_count = each.value.branch_protection.required_approving_review_count
+    required_approving_review_count = local.repositories[each.key].branch_protection.required_approving_review_count
   }
 
   depends_on = [
@@ -102,8 +102,8 @@ resource "github_branch_protection" "main" {
 }
 
 resource "github_actions_repository_permissions" "core_cloud_repositories" {
-  for_each   = local.repositories
-  repository = github_repository.core_cloud_repositories[each.key].node_id
+  for_each   = github_repository.core_cloud_repositories
+  repository = each.key
 
   allowed_actions = "selected"
   enabled         = true

--- a/repositories.tf
+++ b/repositories.tf
@@ -9,8 +9,8 @@ locals {
 
   repository_config = {
     "core-cloud" = {
-      visibility = "public"
-      description = "SAS Core Cloud Documentation"
+      visibility   = "public"
+      description  = "SAS Core Cloud Documentation"
       homepage_url = "https://ukhomeoffice.github.io/core-cloud/"
 
       branch_protection = {
@@ -18,11 +18,11 @@ locals {
       }
     },
     "core-cloud-lza-config" = {
-      visibility = "internal"
+      visibility  = "internal"
       description = "SAS Core Cloud LZA Config"
     },
     "core-cloud-github-config" = {
-      visibility = "public"
+      visibility  = "public"
       description = "GitHub repository configuration for Core Cloud repositories"
     }
   }
@@ -34,20 +34,20 @@ locals {
 }
 
 resource "github_repository" "core_cloud_repositories" {
-  for_each           = local.repositories
-  name               = each.key
-  description        = each.value.description
-  visibility         = each.value.visibility
-  has_issues         = false
-  has_projects       = false
-  has_wiki           = false
-  has_downloads      = false
-  allow_merge_commit = false
-  allow_squash_merge = true
-  allow_rebase_merge = false
-  allow_update_branch = true
+  for_each               = local.repositories
+  name                   = each.key
+  description            = each.value.description
+  visibility             = each.value.visibility
+  has_issues             = false
+  has_projects           = false
+  has_wiki               = false
+  has_downloads          = false
+  allow_merge_commit     = false
+  allow_squash_merge     = true
+  allow_rebase_merge     = false
+  allow_update_branch    = true
   delete_branch_on_merge = true
-  homepage_url       = try(each.value.homepage_url, null)
+  homepage_url           = try(each.value.homepage_url, null)
 
   lifecycle {
     prevent_destroy = true

--- a/repositories.tf
+++ b/repositories.tf
@@ -78,8 +78,7 @@ resource "github_branch_protection" "main" {
   allows_deletions = false
 
   required_pull_request_reviews {
-    dismiss_stale_reviews = true
-    require_last_push_approval = true # TODO: this is not in the AC but feels appropriate
+    require_last_push_approval = true
     required_approving_review_count = each.value.branch_protection.required_approving_review_count
   }
 

--- a/repositories.tf
+++ b/repositories.tf
@@ -41,6 +41,10 @@ resource "github_team_repository" "core_cloud_admin_team_repositories" {
   repository = each.key
   team_id = data.github_team.core_cloud_admin.id
   permission = "admin"
+
+  depends_on = [
+    github_repository.core_cloud_repositories
+  ]
 }
 
 resource "github_team_repository" "core_cloud_devops_team_repositories" {
@@ -48,4 +52,8 @@ resource "github_team_repository" "core_cloud_devops_team_repositories" {
   repository = each.key
   team_id = data.github_team.core_cloud_devops.id
   permission = "push"
+
+  depends_on = [
+    github_repository.core_cloud_repositories
+  ]
 }

--- a/repositories.tf
+++ b/repositories.tf
@@ -64,6 +64,7 @@ resource "github_branch_protection" "main" {
   enforce_admins                  = true
   required_linear_history         = true
   require_conversation_resolution = true
+  require_signed_commits          = true
   allows_force_pushes             = false
   allows_deletions                = false
 

--- a/repositories.tf
+++ b/repositories.tf
@@ -29,7 +29,7 @@ resource "github_repository" "core_cloud_repositories" {
   has_downloads      = false
   allow_merge_commit = false
   allow_squash_merge = true
-  allow_rebase_merge = true # TODO: Do we actually want to allow this?
+  allow_rebase_merge = false
 }
 
 resource "github_team_repository" "core_cloud_admin_team_repositories" {

--- a/repositories.tf
+++ b/repositories.tf
@@ -1,7 +1,5 @@
 locals {
   default_repo = {
-    visibility = "private"
-
     branch_protection = {
       required_approving_review_count = 1 # TODO: default to one reviewer except for repositories that need additional scrutiny
     }

--- a/repositories.tf
+++ b/repositories.tf
@@ -82,9 +82,10 @@ resource "github_actions_repository_permissions" "core_cloud_repositories" {
 
   allowed_actions_config {
     github_owned_allowed = true
-    verified_allowed     = true
+    verified_allowed     = false
     patterns_allowed = [
-      "aws-actions/*"
+      "aws-actions/*",
+      "hashicorp/*"
     ]
   }
 }

--- a/repositories.tf
+++ b/repositories.tf
@@ -44,6 +44,8 @@ resource "github_repository" "core_cloud_repositories" {
   allow_merge_commit = false
   allow_squash_merge = true
   allow_rebase_merge = false
+  allow_update_branch = true
+  delete_branch_on_merge = true
 
   lifecycle {
     prevent_destroy = true

--- a/repositories.tf
+++ b/repositories.tf
@@ -79,3 +79,23 @@ resource "github_branch_protection" "main" {
     github_repository.core_cloud_repositories
   ]
 }
+
+resource "github_actions_repository_permissions" "core_cloud_repositories" {
+  for_each = local.repositories
+  repository = github_repository.core_cloud_repositories[each.key].node_id
+
+  allowed_actions = "selected"
+  enabled = true
+
+  allowed_actions_config {
+    github_owned_allowed = true
+    verified_allowed = true
+    patterns_allowed = [
+      "aws-actions/*"
+    ]
+  }
+
+  depends_on = [
+    github_repository.core_cloud_repositories
+  ]
+}

--- a/repositories.tf
+++ b/repositories.tf
@@ -1,0 +1,33 @@
+locals {
+  repository_config = {
+    "core-cloud" = {
+      visibility = "public"
+    },
+    "core-cloud-lza-config" = {
+      visibility = "internal"
+    },
+    "core-cloud-github-config" = {
+      visibility = "public"
+    }
+  }
+
+  # Sets the default of specific values if the object key is not set.
+  repositories = {
+    for k, v in local.repository_config : k => {
+      visibility = try(v.visibility, "private")
+    }
+  }
+}
+
+resource "github_repository" "core_cloud_repositories" {
+  for_each           = local.repositories
+  name               = each.key
+  visibility         = each.value.visibility
+  has_issues         = false
+  has_projects       = false
+  has_wiki           = false
+  has_downloads      = false
+  allow_merge_commit = false
+  allow_squash_merge = true
+  allow_rebase_merge = true # TODO: Do we actually want to allow this?
+}

--- a/repositories.tf
+++ b/repositories.tf
@@ -41,6 +41,10 @@ resource "github_repository" "core_cloud_repositories" {
 
   lifecycle {
     prevent_destroy = true
+
+    ignore_changes = [
+      pages
+    ]
   }
 }
 

--- a/repositories.tf
+++ b/repositories.tf
@@ -75,10 +75,6 @@ resource "github_team_repository" "core_cloud_devops_team_repositories" {
   repository = each.key
   team_id    = data.github_team.core_cloud_devops.id
   permission = "push"
-
-  depends_on = [
-    github_repository.core_cloud_repositories
-  ]
 }
 
 resource "github_branch_protection" "main" {
@@ -96,10 +92,6 @@ resource "github_branch_protection" "main" {
     require_last_push_approval      = true
     required_approving_review_count = local.repositories[each.key].branch_protection.required_approving_review_count
   }
-
-  depends_on = [
-    github_repository.core_cloud_repositories
-  ]
 }
 
 resource "github_actions_repository_permissions" "core_cloud_repositories" {
@@ -116,8 +108,4 @@ resource "github_actions_repository_permissions" "core_cloud_repositories" {
       "aws-actions/*"
     ]
   }
-
-  depends_on = [
-    github_repository.core_cloud_repositories
-  ]
 }

--- a/repositories.tf
+++ b/repositories.tf
@@ -30,6 +30,10 @@ resource "github_repository" "core_cloud_repositories" {
   allow_merge_commit = false
   allow_squash_merge = true
   allow_rebase_merge = false
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "github_team_repository" "core_cloud_admin_team_repositories" {

--- a/repositories.tf
+++ b/repositories.tf
@@ -46,6 +46,7 @@ resource "github_repository" "core_cloud_repositories" {
   allow_squash_merge     = true
   allow_rebase_merge     = false
   allow_update_branch    = true
+  allow_auto_merge       = true
   delete_branch_on_merge = true
   homepage_url           = try(each.value.homepage_url, null)
 

--- a/repositories.tf
+++ b/repositories.tf
@@ -45,9 +45,9 @@ resource "github_repository" "core_cloud_repositories" {
 }
 
 resource "github_team_repository" "core_cloud_admin_team_repositories" {
-  for_each = local.repositories
+  for_each   = local.repositories
   repository = each.key
-  team_id = data.github_team.core_cloud_admin.id
+  team_id    = data.github_team.core_cloud_admin.id
   permission = "admin"
 
   depends_on = [
@@ -56,9 +56,9 @@ resource "github_team_repository" "core_cloud_admin_team_repositories" {
 }
 
 resource "github_team_repository" "core_cloud_devops_team_repositories" {
-  for_each = local.repositories
+  for_each   = local.repositories
   repository = each.key
-  team_id = data.github_team.core_cloud_devops.id
+  team_id    = data.github_team.core_cloud_devops.id
   permission = "push"
 
   depends_on = [
@@ -67,18 +67,18 @@ resource "github_team_repository" "core_cloud_devops_team_repositories" {
 }
 
 resource "github_branch_protection" "main" {
-  for_each = local.repositories
+  for_each      = local.repositories
   repository_id = github_repository.core_cloud_repositories[each.key].node_id
 
-  pattern       = "main"
-  enforce_admins = true
-  required_linear_history = true
+  pattern                         = "main"
+  enforce_admins                  = true
+  required_linear_history         = true
   require_conversation_resolution = true
-  allows_force_pushes = false
-  allows_deletions = false
+  allows_force_pushes             = false
+  allows_deletions                = false
 
   required_pull_request_reviews {
-    require_last_push_approval = true
+    require_last_push_approval      = true
     required_approving_review_count = each.value.branch_protection.required_approving_review_count
   }
 
@@ -88,15 +88,15 @@ resource "github_branch_protection" "main" {
 }
 
 resource "github_actions_repository_permissions" "core_cloud_repositories" {
-  for_each = local.repositories
+  for_each   = local.repositories
   repository = github_repository.core_cloud_repositories[each.key].node_id
 
   allowed_actions = "selected"
-  enabled = true
+  enabled         = true
 
   allowed_actions_config {
     github_owned_allowed = true
-    verified_allowed = true
+    verified_allowed     = true
     patterns_allowed = [
       "aws-actions/*"
     ]

--- a/repositories.tf
+++ b/repositories.tf
@@ -47,6 +47,10 @@ resource "github_team_repository" "core_cloud_admin_team_repositories" {
   repository = each.key
   team_id    = data.github_team.core_cloud_admin.id
   permission = "admin"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "github_team_repository" "core_cloud_devops_team_repositories" {
@@ -54,6 +58,10 @@ resource "github_team_repository" "core_cloud_devops_team_repositories" {
   repository = each.key
   team_id    = data.github_team.core_cloud_devops.id
   permission = "push"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "github_branch_protection" "main" {
@@ -72,6 +80,10 @@ resource "github_branch_protection" "main" {
     require_last_push_approval      = true
     required_approving_review_count = 1
   }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "github_actions_repository_permissions" "core_cloud_repositories" {
@@ -88,5 +100,9 @@ resource "github_actions_repository_permissions" "core_cloud_repositories" {
       "aws-actions/*",
       "hashicorp/*"
     ]
+  }
+
+  lifecycle {
+    prevent_destroy = true
   }
 }

--- a/repositories.tf
+++ b/repositories.tf
@@ -57,3 +57,25 @@ resource "github_team_repository" "core_cloud_devops_team_repositories" {
     github_repository.core_cloud_repositories
   ]
 }
+
+resource "github_branch_protection" "main" {
+  for_each = local.repositories
+  repository_id = github_repository.core_cloud_repositories[each.key].node_id
+
+  pattern       = "main"
+  enforce_admins = true
+  required_linear_history = true
+  require_conversation_resolution = true
+  allows_force_pushes = false
+  allows_deletions = false
+
+  required_pull_request_reviews {
+    dismiss_stale_reviews = true
+    require_last_push_approval = true # TODO: this is not in the AC but feels appropriate
+    required_approving_review_count = 1 # TODO: should this be 1/2, I think some repositories we would want this to be 2 but not all to keep pace.
+  }
+
+  depends_on = [
+    github_repository.core_cloud_repositories
+  ]
+}

--- a/repositories.tf
+++ b/repositories.tf
@@ -58,14 +58,10 @@ resource "github_repository" "core_cloud_repositories" {
 }
 
 resource "github_team_repository" "core_cloud_admin_team_repositories" {
-  for_each   = local.repositories
+  for_each   = github_repository.core_cloud_repositories
   repository = each.key
   team_id    = data.github_team.core_cloud_admin.id
   permission = "admin"
-
-  depends_on = [
-    github_repository.core_cloud_repositories
-  ]
 }
 
 resource "github_team_repository" "core_cloud_devops_team_repositories" {

--- a/repositories.tf
+++ b/repositories.tf
@@ -11,6 +11,7 @@ locals {
     "core-cloud" = {
       visibility = "public"
       description = "SAS Core Cloud Documentation"
+      homepage_url = "https://ukhomeoffice.github.io/core-cloud/"
 
       branch_protection = {
         required_approving_review_count = 1
@@ -46,6 +47,7 @@ resource "github_repository" "core_cloud_repositories" {
   allow_rebase_merge = false
   allow_update_branch = true
   delete_branch_on_merge = true
+  homepage_url       = try(each.value.homepage_url, null)
 
   lifecycle {
     prevent_destroy = true

--- a/teams.tf
+++ b/teams.tf
@@ -1,0 +1,7 @@
+data "github_team" "core_cloud_admin" {
+  slug = "core-cloud-admin"
+}
+
+data "github_team" "core_cloud_devops" {
+  slug = "core-cloud-devops"
+}


### PR DESCRIPTION
This change sets up the project with the current baseline settings for the pre-described GitHub repository settings. It includes a GitHub Action that runs on a push to pull requests to plan and validate the changes made. On a push to main, it conducts a `terraform apply`.