### PR TITLE
LZA-93: correct required checks

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -18,11 +18,12 @@ locals {
       description = "GitHub Action to add a customer to the Core Cloud LZA config"
 
       checks = [
-        "Check Transpiled JavaScript",
         "CodeQL",
-        "Continuous Integration",
+        "Check dist/",
+        "GitHub Actions Test",
         "Lint Codebase",
-        "PR Checker"
+        "Semver Check PR Label",
+        "TypeScript Tests"
       ]
     }
   }


### PR DESCRIPTION
The poorly documented checks property was incorrect in the previous commit. This change corrects these to be the lowest level name provided, in this case the `workflow.job.name`