### PR TITLE
LZA-93: correct required checks for shared workflow

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -22,7 +22,7 @@ locals {
         "Check dist/",
         "GitHub Actions Test",
         "Lint Codebase",
-        "Semver Check PR Label",
+        "Semver Check PR Label / Calculate SemVer Value",
         "TypeScript Tests"
       ]
     }


### PR DESCRIPTION
The poorly documented checks property was incorrect in the previous commit. For workflows that use shared workloads the check name is the following: `<this_repo>.workflow.job.name / <shared_repo>/workflow.job.name`.