### PR TITLE
LZA-93: add superlinter to allowed actions

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -116,7 +116,8 @@ resource "github_actions_repository_permissions" "core_cloud_repositories" {
     verified_allowed     = false
     patterns_allowed = [
       "aws-actions/*",
-      "hashicorp/*"
+      "hashicorp/*",
+      "superlinter/superlinter"
     ]
   }
 


### PR DESCRIPTION
This allows the superlinter action to be run against the repositories.

Due diligence has been performed on this action to ensure we are happy with adding it:
- We have 'trust by proxy' as the GitHub typescript template action uses it. 
- The 🔒 [tech-register](https://technology-register-dev.internal.cto-notprod.homeoffice.gov.uk/) does not currently contain another software marked as a linter.
- The software appears to be well maintained, with frequent updates, used by >1k repos and has 233 contributors.
- No public security issues have been reported. 