### PR TITLE
LZA-93: add wildcard to superlinter

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -117,7 +117,7 @@ resource "github_actions_repository_permissions" "core_cloud_repositories" {
     patterns_allowed = [
       "aws-actions/*",
       "hashicorp/*",
-      "superlinter/superlinter"
+      "superlinter/superlinter/*"
     ]
   }
 


### PR DESCRIPTION
This wildcard allows for any package and version from the superlinter action to be run.