### PR TITLE
LZA-93: add slack actions to allowed actions

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -117,6 +117,7 @@ resource "github_actions_repository_permissions" "core_cloud_repositories" {
     patterns_allowed = [
       "aws-actions/*",
       "hashicorp/*",
+      "slackapi/*",
       "super-linter/super-linter/*"
     ]
   }


### PR DESCRIPTION
This allows the slack actions to be run against the repositories.

Due diligence has been performed on this action to ensure we are happy with adding it:
- We have existing repositories within the organisation that already use this action. 
- We use Slack widespread throughout the organisation.
- Whilst Slack is 'deprecated' on the 🔒 [tech-register](https://technology-register-dev.internal.cto-notprod.homeoffice.gov.uk/), it has a 2 year waiver.
- Repo hasn't had any releases in a while but is actively maintained. We could request a release though.
- No public security issues have been reported.