### PR TITLE
LZA-129: reinstate prevent_destroy on `main` branch protection

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -132,7 +132,7 @@ resource "github_branch_protection" "main" {
   }
 
   lifecycle {
-    prevent_destroy = false
+    prevent_destroy = true
   }
 }
 


### PR DESCRIPTION
Re-enable prevent destroy of branch protection rule after importing newly controlled repos.

I have:

- [X] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
