### PR TITLE
LZA-126: aquasecurity to allowed actions config

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -154,7 +154,8 @@ resource "github_actions_repository_permissions" "core_cloud_repositories" {
       "aws-actions/*",
       "hashicorp/*",
       "slackapi/*",
-      "super-linter/super-linter/*"
+      "super-linter/super-linter/*",
+      "aquasecurity/*",
     ]
   }
 


### PR DESCRIPTION
I have:

- [X] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
