### PR TITLE
LZA-126: add repository for terraform modules

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -32,6 +32,10 @@ locals {
       visibility  = "internal"
       description = "Terraform module for creating and handling Identity Center groups, users, permission sets, assignments, and memberships"
     },
+    "core-cloud-terraform-modules" = {
+      visibility  = "internal"
+      description = "Repository for Terraform modules used by the Core Cloud team"
+    },
     "semver-calculate-action" = {
       visibility  = "public"
       description = "GitHub Action that increments SemVer values"


### PR DESCRIPTION
I have:

- [X] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
