### PR TITLE
LZA-164: add paths filter to allowed actions

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -164,6 +164,7 @@ resource "github_actions_repository_permissions" "core_cloud_repositories" {
       "slackapi/*",
       "super-linter/super-linter/*",
       "aquasecurity/*",
+      "dorny/paths-filter/*"
     ]
   }
 


### PR DESCRIPTION
I have:

- [X] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
