### PR TITLE
fix: update Terraform modules repository to be public

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -37,7 +37,7 @@ locals {
       description = "Terraform module for creating and handling platform specific Identity Center groups, users, permission sets, assignments, and memberships"
     },
     "core-cloud-terraform-modules" = {
-      visibility  = "internal"
+      visibility  = "public"
       description = "Repository for Terraform modules used by the Core Cloud team"
     },
     "semver-calculate-action" = {


### PR DESCRIPTION
I have:

- [X] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
