### PR TITLE
fix: add checks for tenant iam terraform

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -31,6 +31,12 @@ locals {
     "core-cloud-lza-iam-terraform" = {
       visibility  = "internal"
       description = "Terraform module for creating and handling Identity Center groups, users, permission sets, assignments, and memberships"
+
+      checks = [
+        "Run Terraform SAST",
+        "Validate Terraform (Dev) / Assert Environment Directory",
+        "Validate Terraform (Dev) / Plan and optionally Apply Environment Terraform"
+      ]
     },
     "core-cloud-lza-platform-iam-terraform" = {
       visibility  = "internal"


### PR DESCRIPTION
I have:

- [X] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
