### PR TITLE
fix: correct check to job name

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -34,8 +34,7 @@ locals {
 
       checks = [
         "Run Terraform SAST",
-        "Validate Terraform (Dev) / Assert Environment Directory",
-        "Validate Terraform (Dev) / Plan and optionally Apply Environment Terraform"
+        "Validate Terraform (Dev)"
       ]
     },
     "core-cloud-lza-platform-iam-terraform" = {


### PR DESCRIPTION
I have:

- [X] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
