### PR TITLE
fix: add checks for platform iam terraform

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -41,6 +41,11 @@ locals {
     "core-cloud-lza-platform-iam-terraform" = {
       visibility  = "internal"
       description = "Terraform module for creating and handling platform specific Identity Center groups, users, permission sets, assignments, and memberships"
+
+      checks = [
+        "Run Terraform SAST",
+        "Validate Terraform (Dev)"
+      ]
     },
     "core-cloud-terraform-modules" = {
       visibility  = "public"


### PR DESCRIPTION
I have:

- [X] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
