### PR TITLE
fix: add checks for GitHub repo Terraform validation

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -14,6 +14,10 @@ locals {
       visibility                    = "public"
       description                   = "GitHub repository configuration for Core Cloud repositories"
       include_pull_request_template = true
+
+      checks = [
+        "Validate Terraform"
+      ]
     },
     "core-cloud-add-customer-action" = {
       visibility  = "public"


### PR DESCRIPTION
I have:

- [X] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
