### PR TITLE
feat: add repository for GitHub status check action

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -32,6 +32,10 @@ locals {
         "TypeScript Tests"
       ]
     },
+    "core-cloud-github-status-check-action" = {
+      visibility  = "public"
+      description = "GitHub Action to update the status of a GitHub commit"
+    },
     "core-cloud-lza-iam-terraform" = {
       visibility  = "internal"
       description = "Terraform module for creating and handling Identity Center groups, users, permission sets, assignments, and memberships"


### PR DESCRIPTION
I have:

- [X] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
