### PR TITLE
fix: remove check from tenant iam terraform repo

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -41,8 +41,7 @@ locals {
       description = "Terraform module for creating and handling Identity Center groups, users, permission sets, assignments, and memberships"
 
       checks = [
-        "Run Terraform SAST",
-        "Validate Terraform (Dev)"
+        "Run Terraform SAST"
       ]
     },
     "core-cloud-lza-platform-iam-terraform" = {


### PR DESCRIPTION
I have:

- [X] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
