### PR TITLE
fix: add check for label to lza config repo

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -9,6 +9,10 @@ locals {
       visibility                    = "internal"
       description                   = "SAS Core Cloud LZA Config"
       include_pull_request_template = true
+
+      checks = [
+        "Check PR for SemVer Label"
+      ]
     },
     "core-cloud-github-config" = {
       visibility                    = "public"


### PR DESCRIPTION
I have:

- [X] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
