### PR TITLE
ci: add environmental status checks for iam terraform repos

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -45,7 +45,9 @@ locals {
       description = "Terraform module for creating and handling Identity Center groups, users, permission sets, assignments, and memberships"
 
       checks = [
-        "Run Terraform SAST"
+        "Run Terraform SAST",
+        "Validate Terraform (Dev)",
+        "Validate Terraform (Prod)"
       ]
     },
     "core-cloud-lza-platform-iam-terraform" = {
@@ -54,7 +56,8 @@ locals {
 
       checks = [
         "Run Terraform SAST",
-        "Validate Terraform (Dev)"
+        "Validate Terraform (Dev)",
+        "Validate Terraform (Prod)"
       ]
     },
     "core-cloud-lza-management-bootstrap" = {


### PR DESCRIPTION
I have:

- [X] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
