### PR TITLE
config: add required checks for repositories

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -39,6 +39,15 @@ locals {
     "core-cloud-github-status-check-action" = {
       visibility  = "public"
       description = "GitHub Action to update the status of a GitHub commit"
+
+      checks = [
+        "CodeQL",
+        "Check PR for SemVer Label",
+        "Check dist/",
+        "GitHub Actions Test",
+        "Lint Codebase",
+        "TypeScript Tests"
+      ]
     },
     "core-cloud-lza-iam-terraform" = {
       visibility  = "internal"
@@ -71,6 +80,10 @@ locals {
     "core-cloud-terraform-modules" = {
       visibility  = "public"
       description = "Repository for Terraform modules used by the Core Cloud team"
+
+      checks = [
+        "Run Terraform SAST"
+      ]
     },
     "semver-calculate-action" = {
       visibility  = "public"


### PR DESCRIPTION
I have:

- [X] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
