### PR TITLE
Adding terragrunt repo to create static sites

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -134,6 +134,15 @@ locals {
         "diff / Diff Dist (20.x)",
         "test / Unit and Integration Tests (20.x)",
       ]
+    },
+    "core-cloud-static-site-terragrunt" = {
+      visibility  = "internal"
+      description = "Terragrunt module for creating static sites"
+
+      checks = [
+        "Terraform Plans Result",
+        "Scan Terraform Config",
+      ]
     }
   }
 }


### PR DESCRIPTION
I have:

- [x] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
