### PR TITLE
CCL-18 - Adding Terragrunt action to allow list

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -240,7 +240,8 @@ resource "github_actions_repository_permissions" "core_cloud_repositories" {
       "super-linter/super-linter/*",
       "aquasecurity/*",
       "dorny/paths-filter@v*",
-      "octokit/request-action@v*"
+      "octokit/request-action@v*",
+      "gruntwork-io/terragrunt-action@v*"
     ]
   }
 


### PR DESCRIPTION
I have:

- [x] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
