### PR TITLE
Create code owners team as a sub-team of core-cloud-devops.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Add all engineers form the code-owners team to be owners of this repo
+# @org/team-name
+@UKHomeOffice/core-cloud-code-owners

--- a/repositories.tf
+++ b/repositories.tf
@@ -196,6 +196,18 @@ resource "github_team_repository" "core_cloud_devops_team_repositories" {
   }
 }
 
+# Add explicit write permission for code owners for branch protection via CODEOWNERS file
+resource "github_team_repository" "core_cloud_code_owners_team_repositories" {
+  for_each   = github_repository.core_cloud_repositories
+  repository = each.key
+  team_id    = github_team.core_cloud_code_owners.id
+  permission = "write"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 resource "github_branch_protection" "main" {
   for_each      = github_repository.core_cloud_repositories
   repository_id = each.key
@@ -211,6 +223,7 @@ resource "github_branch_protection" "main" {
   required_pull_request_reviews {
     require_last_push_approval      = true
     required_approving_review_count = 1
+    require_code_owner_reviews      = true
   }
 
   required_status_checks {

--- a/teams.tf
+++ b/teams.tf
@@ -1,7 +1,12 @@
+data "github_team" "core_cloud_devops" {
+  slug = "core-cloud-devops"
+}
+
 data "github_team" "core_cloud_admin" {
   slug = "core-cloud-admin"
 }
 
-data "github_team" "core_cloud_devops" {
-  slug = "core-cloud-devops"
+resource "github_team" "core_cloud_code_owners" {
+  name           = "core-cloud-code-owners"
+  parent_team_id = data.github_team.core_cloud_devops.id
 }


### PR DESCRIPTION
Create code owners team as a sub-team of core-cloud-devops.
Add require code owners review to main branch protection.
Give explicit write permission to code owners team to all repos - required for branch protection rule.

Once the changes are in place, I will add the required core-cloud team to the code owners team to allow them to review future PRs.

I have:

- [/ ] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention)
