### PR TITLE
Creating repository for the public DNS bootstrap poc

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -67,6 +67,15 @@ locals {
         "Scan Terraform Config",
       ]
     },
+    "core-cloud-dns-bootstrap" = {
+      visibility  = "internal"
+      description = "Terraform module to bootstrap public DNS Routing (Proof of Concept)"
+
+      checks = [
+        "Terraform Plans Result",
+        "Scan Terraform Config",
+      ]
+    },
     "core-cloud-lza-iam-terraform" = {
       visibility  = "internal"
       description = "Terraform module for creating and handling Identity Center groups, users, permission sets, assignments, and memberships"


### PR DESCRIPTION
I have:

- [x] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
