### PR TITLE
remove check from static site repo

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -140,7 +140,6 @@ locals {
       description = "Terragrunt module for creating static sites"
 
       checks = [
-        "Terraform Plans Result",
         "Scan Terraform Config",
       ]
     }


### PR DESCRIPTION
I have:

- [ ] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
