### PR TITLE
CCL-278 create validator repo

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -152,6 +152,14 @@ locals {
         "Scan Terraform Config",
       ]
     }
+    "core-cloud-lza-validator" = {
+      visibility  = "public"
+      description = "Docker image for validating LZA config"
+
+      checks = [
+
+      ]
+    }
   }
 }
 


### PR DESCRIPTION
I have:

- [ ] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
