### PR TITLE
CC-6 - test/prelive static site repos

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -173,6 +173,20 @@ locals {
 
       checks = [
       ]
+    },
+    "core-cloud-staticsitetest-test-site" = {
+      visibility  = "internal"
+      description = "For platform development work of the static site product in the test environment"
+
+      checks = [
+      ]
+    },
+    "core-cloud-staticsiteprelive-prelive-site" = {
+      visibility  = "internal"
+      description = "For platform development work of the static site product in the prelive environment"
+
+      checks = [
+      ]
     }
   }
 }


### PR DESCRIPTION
I have not:

- [X] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
