### PR TITLE
CC-6 - cleanup temporary test repo

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -166,13 +166,6 @@ locals {
 
       checks = [
       ]
-    }
-    "core-cloud-static-site-tenant-test" = {
-      visibility  = "private"
-      description = "For testing oidc & github actions for tenant static site "
-
-      checks = [
-      ]
     },
     "core-cloud-staticsitetest-test-site" = {
       visibility  = "internal"


### PR DESCRIPTION
I have:

- [X] Validated that any resources created match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention) OR I have validated that if the resources that have been created don't match the [agreed naming convention](https://collaboration.homeoffice.gov.uk/display/CORE/Naming+Convention), that the exception has been logged in the Exceptions table and is deemed as acceptable.
